### PR TITLE
Capture errors and return status codes on queries

### DIFF
--- a/include/bam_api.h
+++ b/include/bam_api.h
@@ -67,7 +67,7 @@ typedef struct bam_aux_header_list {
 } bam_aux_header_list_t;
 
 typedef struct bam_row_set {
-  size_t n_entries;
+  size_t num_entries;
   bam_sequence_row_t **rows;
   bam_aux_header_list_t aux_tags;
 } bam_row_set_t;
@@ -78,6 +78,7 @@ typedef struct offset_node {
 } offset_node_t;
 
 typedef struct offset_list {
+  size_t num_entries;
   struct offset_node *head;
   struct offset_node *tail;
 } offset_list_t;

--- a/include/bam_lmdb.h
+++ b/include/bam_lmdb.h
@@ -16,9 +16,16 @@ typedef struct indices {
 int convert_to_lmdb(samFile *input_file, char *db_path,
                     indices_t *target_indices);
 
-/* Return number of offsets on success, -1 on failure */
-int get_offsets(offset_list_t *offset_list, const char *db_path,
-                const char *index_name, const char *key);
+/** @brief Return matching bam offsets from an LMDB based index
+ *
+ * @param[out] output Offset list to populate with the results
+ * @param[in] db_path Top-level directory of the index database
+ * @param[in] index_name Name of the field to search in
+ * @param[in] key Specific index value to search for
+ * @return 0 on success or a non-zero error value on failure
+ */
+int get_offsets_lmdb(offset_list_t *offset_list, const char *db_path,
+                     const char *index_name, const char *key);
 
 /**
  * Get a list of the available indices in an existing lmdb database
@@ -27,7 +34,20 @@ indices_t *get_available_indices(const char *db_path);
 
 bool is_index_present(const char *db_path, const char *index_name);
 
-bam_row_set_t *get_bam_rows(const char *input_file_name, const char *db_path,
-                            const char *key_type, const char *key_value);
+/** @brief Find all rows matching a key in an indexed bam file
+ *
+ * This function will allocate space for the resulting rows; it is up to the
+ * caller to free the results. Callers should NOT pass a preallocated or
+ * existing row set to this function.
+ *
+ * @param[out] output Location to store the resulting records
+ * @param[in] input_file_name Path of the bam file to query
+ * @param[in] db_path Top-level directory of the index database
+ * @param[in] index_name Name of the field to search in
+ * @param[in] key Specific index value to search for
+ * @return 0 on success or a non-zero error value on failure
+ */
+int get_bam_rows(bam_row_set_t **output, const char *input_file_name,
+                 const char *db_path, const char *index_name, const char *key);
 
 #endif

--- a/include/bamdb_status.h
+++ b/include/bamdb_status.h
@@ -1,6 +1,13 @@
-
+#ifndef BAMDBSTATUS_H
+#define BAMDBSTATUS_H
 
 /** Successful result */
 #define BAMDB_SUCCESS 0
+/** Error reading sequence file */
+#define BAMDB_SEQUENCE_FILE_ERROR -16001
+/** Error deserializing a sequence record */
+#define BAMDB_DESERIALIZE_ERROR -16002
 /** Error at the database level */
-#define BAMDB_DB_ERROR -16000
+#define BAMDB_DB_ERROR -16102
+
+#endif

--- a/src/bamdb.c
+++ b/src/bamdb.c
@@ -369,41 +369,35 @@ int main(int argc, char *argv[]) {
       /* Write resulting rows to file */
       offset_list_t *offset_list = calloc(1, sizeof(offset_list_t));
 
-      rc =
-          get_offsets(offset_list, bam_args.index_file_name, "BX", bam_args.bx);
+      rc = get_offsets_lmdb(offset_list, bam_args.index_file_name, "BX",
+                            bam_args.bx);
       rc = write_row_subset(bam_args.input_file_name, offset_list,
                             bam_args.output_file_name);
       free(offset_list);
     } else {
       /* Print rows in tab delim format */
-      bam_row_set_t *row_set =
-          get_bam_rows(bam_args.input_file_name, bam_args.index_file_name, "BX",
-                       bam_args.bx);
+      bam_row_set_t *row_set = NULL;
+      rc = get_bam_rows(&row_set, bam_args.input_file_name,
+                        bam_args.index_file_name, "BX", bam_args.bx);
 
       if (row_set != NULL) {
-        for (size_t j = 0; j < row_set->n_entries; ++j) {
+        for (size_t j = 0; j < row_set->num_entries; ++j) {
           print_sequence_row(row_set->rows[j]);
         }
         free_row_set(row_set);
       }
     }
   }
-
-  if (bam_args.convert_to == BAMDB_CONVERT_TO_LMDB) {
-    rc = generate_index_file(bam_args.input_file_name,
-                             bam_args.output_file_name);
-  }
-
-  return rc;
 }
 
 void print_bx_rows(char **input_file_name, char **db_path, char **bx) {
-  bam_row_set_t *row_set = get_bam_rows(*input_file_name, *db_path, "BX", *bx);
+  int rc = 0;
+  bam_row_set_t *row_set = NULL;
+  rc = get_bam_rows(&row_set, *input_file_name, *db_path, "BX", *bx);
 
   if (row_set != NULL) {
-    for (size_t j = 0; j < row_set->n_entries; ++j) {
+    for (size_t j = 0; j < row_set->num_entries; ++j) {
       print_sequence_row(row_set->rows[j]);
     }
-    free_row_set(row_set);
   }
 }


### PR DESCRIPTION
This will allow the caller to deal with the outcome as they see fit. We
no longer crash for things like missing keys.