### PR TITLE
Minor tweaks and fixes

### DIFF
--- a/include/bam_api.h
+++ b/include/bam_api.h
@@ -90,7 +90,12 @@ int get_bam_row(bam_sequence_row_t **out, bam_aux_header_list_t *tag_list,
                 const int64_t offset, samFile *input_file, bam_hdr_t *header);
 void print_sequence_row(bam_sequence_row_t *row);
 void destroy_bam_sequence_row(bam_sequence_row_t *row);
-void free_row_set(bam_row_set_t *row_set);
+
+/** @brief Destroy a bamdb row set including all sub objects
+ *
+ * @param[in] row_set The row set to be destroyed
+ */
+void free_bamdb_row_set(bam_row_set_t *row_set);
 
 /* Return 0 on success */
 int write_row_set_to_file(bam_row_set_t *row_set, bam_hdr_t *header,

--- a/include/bam_lmdb.h
+++ b/include/bam_lmdb.h
@@ -37,7 +37,8 @@ bool is_index_present(const char *db_path, const char *index_name);
 /** @brief Find all rows matching a key in an indexed bam file
  *
  * This function will allocate space for the resulting rows; it is up to the
- * caller to free the results. Callers should NOT pass a preallocated or
+ * caller to free the results. In the event of an error we will return an
+ * empty row set object. Callers should NOT pass a preallocated or
  * existing row set to this function.
  *
  * @param[out] output Location to store the resulting records

--- a/src/bam_api.c
+++ b/src/bam_api.c
@@ -423,7 +423,7 @@ void destroy_bam_sequence_row(bam_sequence_row_t *row) {
   free(row);
 }
 
-void free_row_set(bam_row_set_t *row_set) {
+void free_bamdb_row_set(bam_row_set_t *row_set) {
   for (int i = 0; i < row_set->num_entries; ++i) {
     free(row_set->rows[i]);
   }

--- a/src/bam_lmdb.c
+++ b/src/bam_lmdb.c
@@ -513,6 +513,9 @@ int get_bam_rows(bam_row_set_t **output, const char *input_file_name,
   int rc = 0;
   int ret = BAMDB_SUCCESS;
 
+  /* Always create an object for the caller */
+  *output = calloc(1, sizeof(bam_row_set_t));
+
   if ((input_file = sam_open(input_file_name, "r")) == 0) {
     return BAMDB_SEQUENCE_FILE_ERROR;
   }
@@ -529,7 +532,6 @@ int get_bam_rows(bam_row_set_t **output, const char *input_file_name,
     return rc;
   }
 
-  *output = calloc(1, sizeof(bam_row_set_t));
   (*output)->num_entries = offsets->num_entries;
   (*output)->rows = malloc((*output)->num_entries * sizeof(bam_row_set_t));
 

--- a/src/bamdb.c
+++ b/src/bamdb.c
@@ -384,7 +384,7 @@ int main(int argc, char *argv[]) {
         for (size_t j = 0; j < row_set->num_entries; ++j) {
           print_sequence_row(row_set->rows[j]);
         }
-        free_row_set(row_set);
+        free_bamdb_row_set(row_set);
       }
     }
   }


### PR DESCRIPTION
Some renaming, always allocate an object in get_bam_rows so that the
caller can blindly free regardless of whether or not there is an error.